### PR TITLE
Make namespaces unique

### DIFF
--- a/fastscroller-indicator/build.gradle.kts
+++ b/fastscroller-indicator/build.gradle.kts
@@ -49,7 +49,7 @@ kotlin {
 
 android {
     compileSdk = 34
-    namespace = "io.github.oikvpqya.compose.fastscroller"
+    namespace = "io.github.oikvpqya.compose.fastscroller.indicator"
 
     defaultConfig {
         minSdk = 21

--- a/fastscroller-material/build.gradle.kts
+++ b/fastscroller-material/build.gradle.kts
@@ -52,7 +52,7 @@ kotlin {
 
 android {
     compileSdk = 34
-    namespace = "io.github.oikvpqya.compose.fastscroller"
+    namespace = "io.github.oikvpqya.compose.fastscroller.material"
 
     defaultConfig {
         minSdk = 21

--- a/fastscroller-material3/build.gradle.kts
+++ b/fastscroller-material3/build.gradle.kts
@@ -52,7 +52,7 @@ kotlin {
 
 android {
     compileSdk = 34
-    namespace = "io.github.oikvpqya.compose.fastscroller"
+    namespace = "io.github.oikvpqya.compose.fastscroller.material3"
 
     defaultConfig {
         minSdk = 21


### PR DESCRIPTION
While building, I get this warning:

```
[io.github.oikvpqya.compose.fastscroller:fastscroller-material3-android:0.3.0] /home/sproctor/.gradle/caches/8.10.2/transforms/de9ce85bb46f9bca2ebac4916411b9d3/transformed/fastscroller-material3-release/AndroidManifest.xml Warning:
        Namespace 'io.github.oikvpqya.compose.fastscroller' is used in multiple modules and/or libraries: io.github.oikvpqya.compose.fastscroller:fastscroller-material3-android:0.3.0, io.github.oikvpqya.compose.fastscroller:fastscroller-core-android:0.3.0. Please ensure that all modules and libraries have a unique namespace. For more information, See https://developer.android.com/studio/build/configure-app-module#set-namespace
```

This should fix it.